### PR TITLE
fix typo in hunt timeout

### DIFF
--- a/superload/mod/class/Player.lua
+++ b/superload/mod/class/Player.lua
@@ -321,7 +321,7 @@ local function player_ai_act()
             ai_state = PAI_STATE_REST
             hunt_target = nil
             hunt_start = nil
-            return payer_ai_act()
+            return player_ai_act()
         end
 
         local dir = nil


### PR DESCRIPTION
noticed while trying to figure out why I was sometimes getting stuck in hunt mode for extended periods